### PR TITLE
refactor(auth): centralize session storage and harden auth flow

### DIFF
--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
 import process from 'process'
-import { Admin, Session } from '@/models/index.js'
+import { Admin } from '@/models/index.js'
+import { sessionStore } from '@/services/session-store.service.js'
 
 const { JWT_SECRET } = process.env
 if (!JWT_SECRET) throw new Error('JWT_SECRET is not defined.')
@@ -32,55 +33,32 @@ const AuthErrors = {
 } as const
 
 async function validateSession(token: string) {
-    try {
-        console.log(
-            `[Auth Debug] Looking up session for token: ${token.substring(0, 10)}...`,
-        )
-        const session = await Session.findOne({ where: { token } })
+    const session = await sessionStore.findByToken(token)
 
-        if (!session) {
-            console.log('[Auth Debug] Session not found for token')
-            throw new Error(AuthErrors.SESSION_NOT_FOUND.message)
-        }
-
-        console.log(
-            `[Auth Debug] Session found, expiry: ${session.expiryDate}, current time: ${new Date()}`,
-        )
-        if (new Date() > session.expiryDate) {
-            console.log('[Auth Debug] Session expired, destroying session')
-            await Session.destroy({ where: { token } })
-            throw new Error(AuthErrors.SESSION_EXPIRED.message)
-        }
-
-        console.log('[Auth Debug] Session is valid')
-        return true
-    } catch (error) {
-        console.error('[Auth Debug] Session validation error:', error)
-        throw error
+    if (!session) {
+        throw new Error(AuthErrors.SESSION_NOT_FOUND.message)
     }
+
+    if (new Date() > session.expiryDate) {
+        await sessionStore.deleteByToken(token)
+        throw new Error(AuthErrors.SESSION_EXPIRED.message)
+    }
+
+    return true
 }
 
 function getTokenFromRequest(req: Request): string | undefined {
     // Try cookie, then Authorization header (Bearer)
     if (req.cookies?.token) {
-        console.log('[Auth Debug] Token found in cookies')
         return req.cookies.token
     }
 
     const authHeader =
         req.headers['authorization'] || req.headers['Authorization']
     if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
-        console.log('[Auth Debug] Token found in Authorization header')
         return authHeader.slice(7)
     }
 
-    // Additional fallback - check if token is in query params
-    if (req.query?.token && typeof req.query.token === 'string') {
-        console.log('[Auth Debug] Token found in query parameters')
-        return req.query.token
-    }
-
-    console.log('[Auth Debug] No token found in request')
     return undefined
 }
 
@@ -90,12 +68,6 @@ export default function authWithRBAC(
 ) {
     return (req: Request, res: Response, next: NextFunction) => {
         ;(async () => {
-            console.log(
-                `[Auth Debug] authWithRBAC called with roles: ${JSON.stringify(allowedRoles)}, checkSubscription: ${checkSubscriptionForPremiumFeatures}`,
-            )
-            console.log(
-                `[Auth Debug] Request path: ${req.path}, method: ${req.method}`,
-            )
 
             try {
                 // 1) Get and validate token
@@ -109,16 +81,11 @@ export default function authWithRBAC(
                 // 2) Verify JWT
                 let payload: AuthTokenPayload
                 try {
-                    console.log('[Auth Debug] Verifying JWT token')
                     payload = jwt.verify(
                         token,
                         JWT_SECRET as string,
                     ) as AuthTokenPayload
-                    console.log(
-                        `[Auth Debug] JWT verified successfully, payload: id=${payload.userId}, type=${payload.entityType}`,
-                    )
                 } catch (err) {
-                    console.error('[Auth Debug] JWT verification error:', err)
                     let errorMessage = AuthErrors.INVALID_TOKEN.message
 
                     if (err instanceof jwt.TokenExpiredError) {
@@ -134,10 +101,6 @@ export default function authWithRBAC(
                 }
 
                 if (!payload?.userId || !payload.entityType) {
-                    console.log(
-                        '[Auth Debug] Payload missing required fields:',
-                        payload,
-                    )
                     return res.status(AuthErrors.INVALID_TOKEN.status).json({
                         error: AuthErrors.INVALID_TOKEN.message,
                         details: 'Token payload missing id or entityType',
@@ -146,7 +109,6 @@ export default function authWithRBAC(
 
                 // 3) Validate session
                 try {
-                    console.log('[Auth Debug] Validating session')
                     await validateSession(token)
                 } catch (error) {
                     const msg = (error as Error).message

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -9,8 +9,8 @@ import {
 } from '@/models/index.js'
 import jwt, { SignOptions } from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
-import { Op } from 'sequelize'
 import process from 'process'
+import { sessionStore } from '@/services/session-store.service.js'
 
 const JWT_SECRET = process.env.JWT_SECRET
 const JWT_EXPIRY = process.env.JWT_EXPIRY || '7d'
@@ -98,16 +98,10 @@ class AuthService {
         ipAddress?: string,
     ): Promise<LoginResponse> {
         // First, delete all expired sessions
-        await Session.destroy({
-            where: {
-                userAgent,
-                expiryDate: { [Op.lte]: new Date() },
-            },
-        })
+        await sessionStore.clearExpiredSessions()
 
         const user = await userModel.findOne({ where: { email } })
         const userStringify = JSON.parse(JSON.stringify(user))
-        console.log(userStringify)
         if (!user) {
             throw new Error('Invalid credentials')
         }
@@ -121,14 +115,7 @@ class AuthService {
         }
 
         // Check if an active session already exists for the user with the same entityType
-        const activeSession = await Session.findOne({
-            where: {
-                userId: userStringify.id,
-                userAgent,
-                entityType: entityType,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(userStringify.id, entityType, userAgent)
 
         if (activeSession) {
             // Return existing session token if active session is found
@@ -155,7 +142,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: user.id,
             entityType: entityType,
             token: token,
@@ -202,14 +189,7 @@ class AuthService {
         )
         if (!passwordMatch) throw new Error('Invalid Credentials')
         // Check if an active session already exists for the user with the same entityType
-        const activeSession = await Session.findOne({
-            where: {
-                userId: isUserExists.id,
-                userAgent,
-                entityType: entityType,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(isUserExists.id, entityType, userAgent)
 
         if (activeSession) {
             // Return existing session token if active session is found
@@ -236,7 +216,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: isUserExists.id,
             entityType: entityType,
             token: token,
@@ -285,14 +265,7 @@ class AuthService {
         )
         if (!passwordMatch) throw new Error('Invalid Credentials')
         // Check if an active session already exists for the user with the same entityType
-        const activeSession = await Session.findOne({
-            where: {
-                userId: isTeacherExists.id,
-                userAgent,
-                entityType: entityType,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(isTeacherExists.id, entityType, userAgent)
 
         if (activeSession) {
             // Return existing session token if active session is found
@@ -319,7 +292,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: isTeacherExists.id,
             entityType: entityType,
             token: token,
@@ -353,14 +326,7 @@ class AuthService {
             ownerExists.password,
         )
         if (!passwordMatch) throw new Error('Wrong password')
-        const activeSession = await Session.findOne({
-            where: {
-                userId: ownerExists.id,
-                entityType: 'OWNER',
-                userAgent,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(ownerExists.id, 'OWNER', userAgent)
         if (activeSession) throw new Error('Session already exists')
         const payload: CurrentUserPayload = {
             userId: ownerExists.id,
@@ -370,12 +336,7 @@ class AuthService {
         if (!JWT_SECRET) {
             throw new Error('JWT_SECRET is not defined')
         }
-        await Session.destroy({
-            where: {
-                userAgent,
-                expiryDate: { [Op.lte]: new Date() },
-            },
-        })
+        await sessionStore.clearExpiredSessions()
 
         const token = jwt.sign(payload, JWT_SECRET, {
             expiresIn: JWT_EXPIRY,
@@ -384,7 +345,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: ownerExists.id,
             entityType: 'OWNER',
             token: token,
@@ -445,9 +406,7 @@ class AuthService {
         entityType: EntityType,
         userAgent: string,
     ): Promise<void> {
-        await Session.destroy({
-            where: { token, userAgent, userId, entityType },
-        })
+        await sessionStore.deleteByCriteria({ token, userAgent, userId, entityType })
     }
 
     /**
@@ -465,7 +424,7 @@ class AuthService {
      */
     async getCurrentUser(token: string): Promise<CurrentUserPayload | null> {
         try {
-            const session = await Session.findOne({ where: { token } })
+            const session = await sessionStore.findByToken(token)
             if (!session || session.expiryDate < new Date()) {
                 return null
             }

--- a/src/services/session-store.service.ts
+++ b/src/services/session-store.service.ts
@@ -1,0 +1,70 @@
+import { Op } from 'sequelize'
+import { Session } from '@/models/index.js'
+import process from 'process'
+
+const SESSION_TTL_SECONDS = parseInt(process.env.SESSION_EXPIRY_HOURS || '168', 10) * 3600
+
+interface SessionRecord {
+    token: string
+    userId: number
+    entityType: string
+    expiryDate: Date
+    userAgent?: string
+    ipAddress?: string
+    isSuperAdmin?: boolean
+}
+
+class SessionStoreService {
+    private redisEnabled = process.env.REDIS_AUTH_ENABLED === 'true'
+    private redisUrl = process.env.REDIS_URL
+
+    private redisNotConfigured(): boolean {
+        return this.redisEnabled && !this.redisUrl
+    }
+
+    async create(record: SessionRecord): Promise<void> {
+        await Session.create(record)
+    }
+
+    async findByToken(token: string) {
+        return Session.findOne({ where: { token } })
+    }
+
+    async findActiveSession(userId: number, entityType: string, userAgent?: string) {
+        return Session.findOne({
+            where: {
+                userId,
+                entityType,
+                userAgent,
+                expiryDate: { [Op.gt]: new Date() },
+            },
+        })
+    }
+
+    async deleteByToken(token: string): Promise<void> {
+        await Session.destroy({ where: { token } })
+    }
+
+    async deleteByCriteria(params: {
+        token?: string
+        userId?: number
+        entityType?: string
+        userAgent?: string
+    }): Promise<void> {
+        await Session.destroy({ where: params })
+    }
+
+    async clearExpiredSessions(): Promise<void> {
+        await Session.destroy({ where: { expiryDate: { [Op.lte]: new Date() } } })
+    }
+
+    getSessionTtlSeconds(): number {
+        return SESSION_TTL_SECONDS
+    }
+
+    isRedisConfigured(): boolean {
+        return this.redisEnabled && Boolean(this.redisUrl) && !this.redisNotConfigured()
+    }
+}
+
+export const sessionStore = new SessionStoreService()


### PR DESCRIPTION
### Motivation
- Consolidate session lifecycle and make authentication easier to extend (e.g., Redis-backed sessions) by removing duplicated session logic scattered across auth layers. 
- Improve security and maintainability by narrowing token intake vectors and reducing noisy/unsafe debug logging.

### Description
- Added a new session abstraction `src/services/session-store.service.ts` that centralizes session persistence, TTL handling, and basic Redis readiness flags (`REDIS_AUTH_ENABLED`, `REDIS_URL`).
- Refactored `src/services/auth.service.ts` to route all session operations through `sessionStore` (clear expired sessions, find active sessions, create sessions, delete by criteria) instead of direct model calls. 
- Hardened `src/middleware/auth.middleware.ts` to validate sessions using the `sessionStore`, removed the token-in-query-parameter fallback, and reduced debug logging to avoid token exposure.
- Kept JWT signing/expiry behavior intact and preserved entity-role checks and subscription gating in middleware while centralizing session lifecycle.

### Testing
- Ran lint for the changed files with `pnpm -s eslint src/services/auth.service.ts src/middleware/auth.middleware.ts src/services/session-store.service.ts` which passed for the modified files.
- Attempted a full TypeScript build with `pnpm -s build` which failed due to many pre-existing type and model mismatches across unrelated modules; the failures are not caused by this auth-focused refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1ae054ac83219918f0ee9abeb852)