### PR TITLE
Add session-store abstraction and Redis-backed auth ADR; migrate auth to use sessionStore

### DIFF
--- a/ARCHITECTURE_REDESIGN.md
+++ b/ARCHITECTURE_REDESIGN.md
@@ -1,0 +1,72 @@
+# School Management System — Target Architecture Redesign
+
+## Current Problems
+- Mixed legacy and new domain models are coexisting, causing broken imports and type mismatches.
+- Controllers contain business logic and authentication/session concerns.
+- Auth/session state is inconsistent across middleware, services, and DB assumptions.
+- Build quality gate is failing due to cross-module contract drift.
+
+## Proposed Professional Architecture
+
+### 1) Domain-first modular monolith
+Organize by bounded contexts:
+- `src/modules/auth`
+- `src/modules/users`
+- `src/modules/academics`
+- `src/modules/timetable`
+- `src/modules/exams`
+- `src/modules/fees`
+- `src/modules/core`
+
+Each module contains:
+- `controller/`
+- `service/`
+- `repository/`
+- `dto/`
+- `validator/`
+- `mapper/`
+- `routes/`
+
+### 2) Clean app layers
+- **HTTP layer**: express routes/controllers only parse request/response.
+- **Application layer**: services implement use-cases.
+- **Infrastructure layer**: sequelize repositories, redis adapters, mail adapters.
+
+### 3) Contract unification
+- Keep one source-of-truth per model (sequelize model + zod DTO mapper).
+- Remove duplicated/legacy model exports and mismatched names.
+- Add explicit module public API index files.
+
+### 4) Authentication redesign (smooth + secure)
+- Access token: short-lived JWT (15 min).
+- Refresh token: opaque random token stored in Redis with rotation.
+- Session index in Redis:
+  - `session:{sid}` -> user/session metadata (TTL)
+  - `user_sessions:{userId}` -> set of active session ids
+  - `refresh:{tokenHash}` -> session id (TTL)
+- Revoke on logout by deleting session and rotated refresh tokens.
+- Support per-device sessions with user-agent fingerprint and IP metadata.
+
+### 5) Security baseline
+- Enforce cookie-only refresh token (httpOnly, secure, sameSite=lax/none per env).
+- Keep access token in Authorization header.
+- Add brute-force guard (IP + account key in Redis).
+- Standardize audit logs for auth events (no token data in logs).
+
+### 6) Reliability and maintainability
+- Add lint + typecheck + test as required CI checks.
+- Add migration verification in CI (`sequelize db:migrate:status`).
+- Add architecture decision records (ADRs) under `docs/adr/`.
+
+## Migration Plan (Incremental)
+1. Freeze legacy auth endpoints and create `modules/auth` v2 paths.
+2. Introduce Redis-backed refresh/session service and token rotation.
+3. Replace controller-level DB logic with repositories + services module-by-module.
+4. Remove legacy imports and dead exports after each module cutover.
+5. Enforce strict TS mode module-by-module and fail CI on regressions.
+
+## Definition of Done for “fixed system”
+- `pnpm lint` passes.
+- `pnpm build` passes.
+- auth e2e login/refresh/logout tests pass.
+- legacy duplicate model names removed.

--- a/docs/adr/0001-auth-session-strategy.md
+++ b/docs/adr/0001-auth-session-strategy.md
@@ -1,0 +1,15 @@
+# ADR 0001: Redis-backed Auth Sessions with Rotating Refresh Tokens
+
+## Status
+Accepted
+
+## Context
+The codebase currently has inconsistent assumptions around session persistence and model availability.
+
+## Decision
+Use Redis as the primary auth session store for refresh/session lifecycle. Keep access JWT stateless and short-lived.
+
+## Consequences
+- Better revocation and multi-device session control.
+- Requires Redis availability in production.
+- Reduces direct DB coupling in auth middleware.

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
 import process from 'process'
-import { Admin, Session } from '@/models/index.js'
+import { Admin } from '@/models/index.js'
+import { sessionStore } from '@/services/session-store.service.js'
 
 const { JWT_SECRET } = process.env
 if (!JWT_SECRET) throw new Error('JWT_SECRET is not defined.')
@@ -32,55 +33,32 @@ const AuthErrors = {
 } as const
 
 async function validateSession(token: string) {
-    try {
-        console.log(
-            `[Auth Debug] Looking up session for token: ${token.substring(0, 10)}...`,
-        )
-        const session = await Session.findOne({ where: { token } })
+    const session = await sessionStore.findByToken(token)
 
-        if (!session) {
-            console.log('[Auth Debug] Session not found for token')
-            throw new Error(AuthErrors.SESSION_NOT_FOUND.message)
-        }
-
-        console.log(
-            `[Auth Debug] Session found, expiry: ${session.expiryDate}, current time: ${new Date()}`,
-        )
-        if (new Date() > session.expiryDate) {
-            console.log('[Auth Debug] Session expired, destroying session')
-            await Session.destroy({ where: { token } })
-            throw new Error(AuthErrors.SESSION_EXPIRED.message)
-        }
-
-        console.log('[Auth Debug] Session is valid')
-        return true
-    } catch (error) {
-        console.error('[Auth Debug] Session validation error:', error)
-        throw error
+    if (!session) {
+        throw new Error(AuthErrors.SESSION_NOT_FOUND.message)
     }
+
+    if (new Date() > session.expiryDate) {
+        await sessionStore.deleteByToken(token)
+        throw new Error(AuthErrors.SESSION_EXPIRED.message)
+    }
+
+    return true
 }
 
 function getTokenFromRequest(req: Request): string | undefined {
     // Try cookie, then Authorization header (Bearer)
     if (req.cookies?.token) {
-        console.log('[Auth Debug] Token found in cookies')
         return req.cookies.token
     }
 
     const authHeader =
         req.headers['authorization'] || req.headers['Authorization']
     if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
-        console.log('[Auth Debug] Token found in Authorization header')
         return authHeader.slice(7)
     }
 
-    // Additional fallback - check if token is in query params
-    if (req.query?.token && typeof req.query.token === 'string') {
-        console.log('[Auth Debug] Token found in query parameters')
-        return req.query.token
-    }
-
-    console.log('[Auth Debug] No token found in request')
     return undefined
 }
 
@@ -90,12 +68,6 @@ export default function authWithRBAC(
 ) {
     return (req: Request, res: Response, next: NextFunction) => {
         ;(async () => {
-            console.log(
-                `[Auth Debug] authWithRBAC called with roles: ${JSON.stringify(allowedRoles)}, checkSubscription: ${checkSubscriptionForPremiumFeatures}`,
-            )
-            console.log(
-                `[Auth Debug] Request path: ${req.path}, method: ${req.method}`,
-            )
 
             try {
                 // 1) Get and validate token
@@ -109,16 +81,11 @@ export default function authWithRBAC(
                 // 2) Verify JWT
                 let payload: AuthTokenPayload
                 try {
-                    console.log('[Auth Debug] Verifying JWT token')
                     payload = jwt.verify(
                         token,
                         JWT_SECRET as string,
                     ) as AuthTokenPayload
-                    console.log(
-                        `[Auth Debug] JWT verified successfully, payload: id=${payload.userId}, type=${payload.entityType}`,
-                    )
                 } catch (err) {
-                    console.error('[Auth Debug] JWT verification error:', err)
                     let errorMessage = AuthErrors.INVALID_TOKEN.message
 
                     if (err instanceof jwt.TokenExpiredError) {
@@ -134,10 +101,6 @@ export default function authWithRBAC(
                 }
 
                 if (!payload?.userId || !payload.entityType) {
-                    console.log(
-                        '[Auth Debug] Payload missing required fields:',
-                        payload,
-                    )
                     return res.status(AuthErrors.INVALID_TOKEN.status).json({
                         error: AuthErrors.INVALID_TOKEN.message,
                         details: 'Token payload missing id or entityType',
@@ -146,7 +109,6 @@ export default function authWithRBAC(
 
                 // 3) Validate session
                 try {
-                    console.log('[Auth Debug] Validating session')
                     await validateSession(token)
                 } catch (error) {
                     const msg = (error as Error).message

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -9,8 +9,8 @@ import {
 } from '@/models/index.js'
 import jwt, { SignOptions } from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
-import { Op } from 'sequelize'
 import process from 'process'
+import { sessionStore } from '@/services/session-store.service.js'
 
 const JWT_SECRET = process.env.JWT_SECRET
 const JWT_EXPIRY = process.env.JWT_EXPIRY || '7d'
@@ -98,16 +98,10 @@ class AuthService {
         ipAddress?: string,
     ): Promise<LoginResponse> {
         // First, delete all expired sessions
-        await Session.destroy({
-            where: {
-                userAgent,
-                expiryDate: { [Op.lte]: new Date() },
-            },
-        })
+        await sessionStore.clearExpiredSessions()
 
         const user = await userModel.findOne({ where: { email } })
         const userStringify = JSON.parse(JSON.stringify(user))
-        console.log(userStringify)
         if (!user) {
             throw new Error('Invalid credentials')
         }
@@ -121,14 +115,7 @@ class AuthService {
         }
 
         // Check if an active session already exists for the user with the same entityType
-        const activeSession = await Session.findOne({
-            where: {
-                userId: userStringify.id,
-                userAgent,
-                entityType: entityType,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(userStringify.id, entityType, userAgent)
 
         if (activeSession) {
             // Return existing session token if active session is found
@@ -155,7 +142,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: user.id,
             entityType: entityType,
             token: token,
@@ -202,14 +189,7 @@ class AuthService {
         )
         if (!passwordMatch) throw new Error('Invalid Credentials')
         // Check if an active session already exists for the user with the same entityType
-        const activeSession = await Session.findOne({
-            where: {
-                userId: isUserExists.id,
-                userAgent,
-                entityType: entityType,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(isUserExists.id, entityType, userAgent)
 
         if (activeSession) {
             // Return existing session token if active session is found
@@ -236,7 +216,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: isUserExists.id,
             entityType: entityType,
             token: token,
@@ -285,14 +265,7 @@ class AuthService {
         )
         if (!passwordMatch) throw new Error('Invalid Credentials')
         // Check if an active session already exists for the user with the same entityType
-        const activeSession = await Session.findOne({
-            where: {
-                userId: isTeacherExists.id,
-                userAgent,
-                entityType: entityType,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(isTeacherExists.id, entityType, userAgent)
 
         if (activeSession) {
             // Return existing session token if active session is found
@@ -319,7 +292,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: isTeacherExists.id,
             entityType: entityType,
             token: token,
@@ -353,14 +326,7 @@ class AuthService {
             ownerExists.password,
         )
         if (!passwordMatch) throw new Error('Wrong password')
-        const activeSession = await Session.findOne({
-            where: {
-                userId: ownerExists.id,
-                entityType: 'OWNER',
-                userAgent,
-                expiryDate: { [Op.gt]: new Date() },
-            },
-        })
+        const activeSession = await sessionStore.findActiveSession(ownerExists.id, 'OWNER', userAgent)
         if (activeSession) throw new Error('Session already exists')
         const payload: CurrentUserPayload = {
             userId: ownerExists.id,
@@ -370,12 +336,7 @@ class AuthService {
         if (!JWT_SECRET) {
             throw new Error('JWT_SECRET is not defined')
         }
-        await Session.destroy({
-            where: {
-                userAgent,
-                expiryDate: { [Op.lte]: new Date() },
-            },
-        })
+        await sessionStore.clearExpiredSessions()
 
         const token = jwt.sign(payload, JWT_SECRET, {
             expiresIn: JWT_EXPIRY,
@@ -384,7 +345,7 @@ class AuthService {
         const expiryDate = new Date()
         expiryDate.setHours(expiryDate.getHours() + SESSION_EXPIRY_HOURS)
 
-        await Session.create({
+        await sessionStore.create({
             userId: ownerExists.id,
             entityType: 'OWNER',
             token: token,
@@ -445,9 +406,7 @@ class AuthService {
         entityType: EntityType,
         userAgent: string,
     ): Promise<void> {
-        await Session.destroy({
-            where: { token, userAgent, userId, entityType },
-        })
+        await sessionStore.deleteByCriteria({ token, userAgent, userId, entityType })
     }
 
     /**
@@ -465,7 +424,7 @@ class AuthService {
      */
     async getCurrentUser(token: string): Promise<CurrentUserPayload | null> {
         try {
-            const session = await Session.findOne({ where: { token } })
+            const session = await sessionStore.findByToken(token)
             if (!session || session.expiryDate < new Date()) {
                 return null
             }

--- a/src/services/session-store.service.ts
+++ b/src/services/session-store.service.ts
@@ -1,0 +1,70 @@
+import { Op } from 'sequelize'
+import { Session } from '@/models/index.js'
+import process from 'process'
+
+const SESSION_TTL_SECONDS = parseInt(process.env.SESSION_EXPIRY_HOURS || '168', 10) * 3600
+
+interface SessionRecord {
+    token: string
+    userId: number
+    entityType: string
+    expiryDate: Date
+    userAgent?: string
+    ipAddress?: string
+    isSuperAdmin?: boolean
+}
+
+class SessionStoreService {
+    private redisEnabled = process.env.REDIS_AUTH_ENABLED === 'true'
+    private redisUrl = process.env.REDIS_URL
+
+    private redisNotConfigured(): boolean {
+        return this.redisEnabled && !this.redisUrl
+    }
+
+    async create(record: SessionRecord): Promise<void> {
+        await Session.create(record)
+    }
+
+    async findByToken(token: string) {
+        return Session.findOne({ where: { token } })
+    }
+
+    async findActiveSession(userId: number, entityType: string, userAgent?: string) {
+        return Session.findOne({
+            where: {
+                userId,
+                entityType,
+                userAgent,
+                expiryDate: { [Op.gt]: new Date() },
+            },
+        })
+    }
+
+    async deleteByToken(token: string): Promise<void> {
+        await Session.destroy({ where: { token } })
+    }
+
+    async deleteByCriteria(params: {
+        token?: string
+        userId?: number
+        entityType?: string
+        userAgent?: string
+    }): Promise<void> {
+        await Session.destroy({ where: params })
+    }
+
+    async clearExpiredSessions(): Promise<void> {
+        await Session.destroy({ where: { expiryDate: { [Op.lte]: new Date() } } })
+    }
+
+    getSessionTtlSeconds(): number {
+        return SESSION_TTL_SECONDS
+    }
+
+    isRedisConfigured(): boolean {
+        return this.redisEnabled && Boolean(this.redisUrl) && !this.redisNotConfigured()
+    }
+}
+
+export const sessionStore = new SessionStoreService()


### PR DESCRIPTION
### Motivation
- The codebase had inconsistent session persistence and direct DB session access scattered in auth logic, causing coupling and duplicated behavior.
- Introduce a single session abstraction to enable a Redis-backed session lifecycle (rotating refresh tokens and per-device sessions) and to prepare for a domain-first modular redesign.

### Description
- Add `src/services/session-store.service.ts` which wraps session operations and exposes `sessionStore` with helpers like `create`, `findByToken`, `findActiveSession`, `deleteByCriteria`, and `clearExpiredSessions`.
- Migrate `src/services/auth.service.ts` to use `sessionStore` instead of direct `Session` model calls and removed raw expired-session cleanup scattered across methods.
- Update `src/middleware/auth.middleware.ts` to validate sessions via `sessionStore`, remove debug logging and the query-parameter token fallback, and keep token extraction to cookie/Authorization header only.
- Add architecture documentation files `ARCHITECTURE_REDESIGN.md` and ADR `docs/adr/0001-auth-session-strategy.md` describing the Redis-backed session strategy and the proposed modular architecture.

### Testing
- No automated tests were run as part of this change; CI is expected to run lint, typecheck, and test suites after this PR is submitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1ae054ac83219918f0ee9abeb852)